### PR TITLE
Improving efficiency when a full image comb is needed

### DIFF
--- a/.MoveFramework/public_include/IMoveManager.h
+++ b/.MoveFramework/public_include/IMoveManager.h
@@ -26,6 +26,7 @@ namespace Move
 		virtual void unsubsribe(IMoveObserver* observer)=0;
 
 		virtual int pairMoves()=0;
+		void setCombInterval(int combInterval);
 
 		virtual IMoveController* getMove(int moveId)=0;
 		virtual INavController* getNav(int navId)=0;

--- a/.MoveFramework/src/BallManager.cpp
+++ b/.MoveFramework/src/BallManager.cpp
@@ -157,4 +157,8 @@ namespace Move
 		colorManager->setColor(balls[moveId], r, g, b);
 	}
 
+	void BallManager::setCombInterval(int combInterval) {
+		contourFinder->setCombInterval(combInterval);
+	}
+
 }

--- a/.MoveFramework/src/BallManager.h
+++ b/.MoveFramework/src/BallManager.h
@@ -46,6 +46,7 @@ namespace Move
 
 		void useAutomaticColors(bool use);
 		void setColor(int moveId, int r, int g, int b);
+		void setCombInterval(int combInterval);									//Minimum duration between each full comb by the camera
 
 	private:
 		Vec3 calculateRealWorldPosition(MoveBall* ball, Kalman& filter);

--- a/.MoveFramework/src/ContourFinder.cpp
+++ b/.MoveFramework/src/ContourFinder.cpp
@@ -5,8 +5,9 @@
 namespace Move
 {
 
-	ContourFinder::ContourFinder(EyeImage* img):img(img)
+	ContourFinder::ContourFinder(EyeImage* img, int combInterval):img(img)
 	{
+		myCombInterval = std::chrono::duration<long, std::ratio<1, 1000>>(combInterval);
 	}
 
 
@@ -17,6 +18,8 @@ namespace Move
 	void ContourFinder::findBalls(std::vector<MoveBall*>& balls, int numBalls)
 	{
 		bool needToComb = false;
+		std::chrono::milliseconds mSec;
+
 		for (int i=0; i<numBalls; i++)
 		{
 			// if the center of the previous ball is in the new ball, don't search for it
@@ -36,7 +39,18 @@ namespace Move
 		// comb image if needed
 		if (needToComb)
 		{
-			combImage(balls, numBalls);
+			/*2015-7-13:
+			If the previous ball isn't overlapping with the current ball, there is a good chance
+			that the ball is outside the camera's view. In this case allowing the camera to comb 
+			through the whole image area continuously would result in very high CPU usage. 
+			Slowing a bit mitigates this issue. When the duration is over 100 milliseconds the tracking
+			starts to lag, without much gain in efficiency.
+			*/
+			mSec = duration_cast<milliseconds>(steady_clock::now() - lastComb);
+			if (mSec > myCombInterval) {
+				combImage(balls, numBalls);
+				lastComb = steady_clock::now();
+			}
 		}
 
 		for (int i=0; i<numBalls; i++)

--- a/.MoveFramework/src/ContourFinder.cpp
+++ b/.MoveFramework/src/ContourFinder.cpp
@@ -7,12 +7,18 @@ namespace Move
 
 	ContourFinder::ContourFinder(EyeImage* img, int combInterval):img(img)
 	{
-		myCombInterval = std::chrono::duration<long, std::ratio<1, 1000>>(combInterval);
+		myCombInterval = std::chrono::duration<long, std::ratio<1, 1000>>(combInterval >= 0 ? combInterval : COMB_INTERVAL_DEFAULT);
+		lastComb = steady_clock::now() - myCombInterval;
 	}
 
 
 	ContourFinder::~ContourFinder()
 	{
+	}
+
+	void ContourFinder::setCombInterval(int combInterval) {
+		if (combInterval >= 0)
+			myCombInterval = std::chrono::duration<long, std::ratio<1, 1000>>(combInterval);
 	}
 
 	void ContourFinder::findBalls(std::vector<MoveBall*>& balls, int numBalls)

--- a/.MoveFramework/src/ContourFinder.h
+++ b/.MoveFramework/src/ContourFinder.h
@@ -4,16 +4,24 @@
 #include "MoveBall.h"
 #include "MoveColors.h"
 #include "EyeImage.h"
+#include <chrono>
+
+using namespace std::chrono;
 
 namespace Move
 {
 	//ball algorithm constants
 	const float BALL_MARGIN=0.3f;
+	const int COMB_INTERVAL_DEFAULT = 100;	
 
 	class ContourFinder
 	{
 	private:
 		EyeImage* img;
+
+		//2015-7-13: interval between combing whole image
+		duration<long, std::ratio<1, 1000>> myCombInterval;
+		steady_clock::time_point lastComb;
 
 	public:
 		ContourFinder(EyeImage* img);

--- a/.MoveFramework/src/ContourFinder.h
+++ b/.MoveFramework/src/ContourFinder.h
@@ -4,7 +4,7 @@
 #include "MoveBall.h"
 #include "MoveColors.h"
 #include "EyeImage.h"
-#include <chrono>
+#include <chrono>			//C++11 feature; requires VC++2012 or above 
 
 using namespace std::chrono;
 
@@ -24,7 +24,7 @@ namespace Move
 		steady_clock::time_point lastComb;
 
 	public:
-		ContourFinder(EyeImage* img);
+		ContourFinder(EyeImage* img, int combInterval = 100);
 		~ContourFinder();
 
 		/**
@@ -33,6 +33,7 @@ namespace Move
 		 * @param numBalls Number of balls.
 		 */
 		void findBalls(std::vector<MoveBall*>& balls, int numBalls);
+		void setCombInterval(int combInterval);											//Minimum duration between each full comb by the camera
 
 	private:
 		/**

--- a/.MoveFramework/src/ContourFinder.h
+++ b/.MoveFramework/src/ContourFinder.h
@@ -24,7 +24,7 @@ namespace Move
 		steady_clock::time_point lastComb;
 
 	public:
-		ContourFinder(EyeImage* img, int combInterval = 100);
+		ContourFinder(EyeImage* img, int combInterval = COMB_INTERVAL_DEFAULT);
 		~ContourFinder();
 
 		/**

--- a/.MoveFramework/src/EyeController.cpp
+++ b/.MoveFramework/src/EyeController.cpp
@@ -149,5 +149,9 @@ namespace Move
 		ballManager->resetPosition=moveId;
 	}
 
+	void EyeController::setCombInterval(int combInterval) {
+		ballManager->setCombInterval(combInterval);
+	}
+
 }
 

--- a/.MoveFramework/src/EyeController.h
+++ b/.MoveFramework/src/EyeController.h
@@ -41,6 +41,8 @@ namespace Move
 		void setColor(int moveId, int r, int g, int b);
 		void resetPosition(int moveId);
 
+		void setCombInterval(int combInterval);									//Minimum duration between each full comb by the camera
+
 	private:
 		void Run();
 		static DWORD WINAPI CaptureThread(LPVOID instance);

--- a/.MoveFramework/src/MoveManager.cpp
+++ b/.MoveFramework/src/MoveManager.cpp
@@ -94,8 +94,17 @@ namespace Move
 
 	void MoveManager::closeCamera()
 	{
-		if (eye) eye->closeCamera();
+		if (eye) {
+			eye->closeCamera();
+			delete eye;								//2015-7-13: This wasn't included in original SDK. Not sure why since a new EyeController will be created with initCamera().
+		}
 		eye = 0;
+
+		for (int i = 0; i < moveCount; i++)
+		{
+			MoveDevice::SetMoveColour(i,0,0,0);		//2015-7-13: Turn off the ball LEDs when the camera is closed.
+		}
+
 	}
 
 	int MoveManager::getMoveCount()

--- a/.MoveFramework/src/MoveManager.cpp
+++ b/.MoveFramework/src/MoveManager.cpp
@@ -136,6 +136,12 @@ namespace Move
 		return MoveDevice::PairMoves();
 	}
 
+	void MoveManager::setCombInterval(int combInterval) {
+		if (eye) {
+			eye->setCombInterval(combInterval);
+		}
+	}
+
 	IMoveController* MoveManager::getMove(int moveId)
 	{
 		return moves[moveId];

--- a/.MoveFramework/src/MoveManager.h
+++ b/.MoveFramework/src/MoveManager.h
@@ -59,6 +59,9 @@ namespace Move
 		//move calibration
 		int pairMoves();
 
+		//Minimum duration between each full comb by the camera
+		void setCombInterval(int combInterval);
+
 		IMoveController* getMove(int moveId);
 		INavController* getNav(int navId);
 		IEyeController* getEye();


### PR DESCRIPTION
If the previous ball isn't overlapping with the current ball, there is a good chance that the ball is outside the camera's view. In this case allowing the camera to comb through the whole image area continuously would result in very high CPU usage. Setting a minimum duration between each full comb mitigates this issue. 

Also switches off the LEDs when closeCamera() is called so that the user would know the camera is closed.
